### PR TITLE
fix: 안쓰는 권한 삭제 및 언어 한국어로 변경

### DIFF
--- a/ios/ygt/Info.plist
+++ b/ios/ygt/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>ko_KR</string>
 	<key>CFBundleDisplayName</key>
-	<string>ygt</string>
+	<string>영감탱</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -48,8 +48,10 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string>직접 촬영한 이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 카메라에 접근합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 앨범에 접근합니다.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -62,10 +64,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>직접 촬영한 이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 카메라에 접근합니다.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>이미지를 첨부하기 위해 $(PRODUCT_NAME) 앱이 앨범에 접근합니다.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
# ⛳️작업 내용
사용안하는 위치권한인 `NSLocationWhenInUseUsageDescription `을 삭제했습니다.
CFBundleDevelopmentRegion을 ko_KR로 변경했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
