### PR TITLE
edit: splash duration 2000 설정

### DIFF
--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -21,6 +21,7 @@ export default function SplashScreen({ navigation: { replace } }: SplashScreenPr
         source={require('../assets/ygt-splash.json')}
         autoPlay
         loop={false}
+        duration={2000}
         style={{ height: 374 }}
         onAnimationFinish={onSplashFinish}
       />


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
splash 아이콘의 애니메이션 duration을 2000으로 수정합니다.

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
![Simulator Screen Recording - iPhone 13 - 2022-06-05 at 10 54 27](https://user-images.githubusercontent.com/69200669/172031600-fe668c68-a252-4366-89ec-295618c9e95a.gif)

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
