### PR TITLE
edit: splash에서 home으로 전환 시 하얀색 깜빡임 제거

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,8 @@ import { YgtStatusBar } from '~/components/YgtStatusBar';
 import MainNavigator from '~/navigation/MainNavigator';
 import theme from '~/styles/theme';
 
+import 'react-native-gesture-handler';
+
 export default function App() {
   return (
     <>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
+    "@react-navigation/stack": "^6.2.1",
     "lottie-ios": "3.2.3",
     "lottie-react-native": "^5.1.3",
     "react": "17.0.2",

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import {
-  createStackNavigator,
-  StackCardStyleInterpolator,
-  StackNavigationOptions,
-} from '@react-navigation/stack';
-import { TransitionSpec } from '@react-navigation/stack/lib/typescript/src/types';
+import { createStackNavigator, StackNavigationOptions } from '@react-navigation/stack';
 
 import HomeScreen from '~/screens/HomeScreen';
 import SplashScreen from '~/screens/SplashScreen';
+import theme from '~/styles/theme';
 
 export type MainNavigatorParamsType = {
   Home: undefined;
@@ -17,30 +13,8 @@ export type MainNavigatorParamsType = {
 
 const Stack = createStackNavigator<MainNavigatorParamsType>();
 
-const animationConfig: TransitionSpec = {
-  animation: 'timing',
-  config: {
-    duration: 0,
-    delay: 0,
-  },
-};
-
-const cardStyleInterpolator: StackCardStyleInterpolator = () => {
-  return {
-    overlayStyle: {
-      backgroundColor: 'transparent',
-    },
-    cardTransparent: true,
-  };
-};
-
 const screenOptions: StackNavigationOptions = {
   presentation: 'transparentModal',
-  gestureEnabled: false,
-  transitionSpec: {
-    open: animationConfig,
-    close: animationConfig,
-  },
 };
 
 export default function MainNavigator() {
@@ -50,7 +24,7 @@ export default function MainNavigator() {
         initialRouteName="Splash"
         screenOptions={() => ({
           headerShown: false,
-          cardStyleInterpolator: cardStyleInterpolator,
+          backgroundColor: theme.color.gray02,
         })}
       >
         <Stack.Screen name="Home" component={HomeScreen} options={screenOptions} />

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import {
-  createNativeStackNavigator,
-  NativeStackNavigationOptions,
-} from '@react-navigation/native-stack';
+  createStackNavigator,
+  StackCardStyleInterpolator,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
+import { TransitionSpec } from '@react-navigation/stack/lib/typescript/src/types';
 
 import HomeScreen from '~/screens/HomeScreen';
 import SplashScreen from '~/screens/SplashScreen';
@@ -13,17 +15,44 @@ export type MainNavigatorParamsType = {
   Splash: undefined;
 };
 
-const Stack = createNativeStackNavigator<MainNavigatorParamsType>();
+const Stack = createStackNavigator<MainNavigatorParamsType>();
 
-const screenOptions: NativeStackNavigationOptions = {
-  header: () => null,
-  animation: 'fade',
+const animationConfig: TransitionSpec = {
+  animation: 'timing',
+  config: {
+    duration: 0,
+    delay: 0,
+  },
+};
+
+const cardStyleInterpolator: StackCardStyleInterpolator = () => {
+  return {
+    overlayStyle: {
+      backgroundColor: 'transparent',
+    },
+    cardTransparent: true,
+  };
+};
+
+const screenOptions: StackNavigationOptions = {
+  presentation: 'transparentModal',
+  gestureEnabled: false,
+  transitionSpec: {
+    open: animationConfig,
+    close: animationConfig,
+  },
 };
 
 export default function MainNavigator() {
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Splash">
+      <Stack.Navigator
+        initialRouteName="Splash"
+        screenOptions={() => ({
+          headerShown: false,
+          cardStyleInterpolator: cardStyleInterpolator,
+        })}
+      >
         <Stack.Screen name="Home" component={HomeScreen} options={screenOptions} />
         <Stack.Screen name="Splash" component={SplashScreen} options={screenOptions} />
       </Stack.Navigator>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from 'react';
-import { Linking, Platform, View } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Linking, Platform, View } from 'react-native';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 
 import { Error } from '~/components/Error';
@@ -11,6 +11,15 @@ const uri = 'https://app.ygtang.kr/';
 export default function HomeScreen() {
   const [isError, setIsError] = useState(false);
   const webViewRef = useRef<WebView>();
+  const fadeAnimationRef = useRef(new Animated.Value(0));
+
+  const animationConfig: Animated.TimingAnimationConfig = useMemo(() => {
+    return { useNativeDriver: false, toValue: 1, duration: 1700 };
+  }, []);
+
+  useEffect(() => {
+    Animated.timing(fadeAnimationRef.current, animationConfig).start();
+  }, [animationConfig]);
 
   const handleExternalLinks = (event: WebViewNavigation) => {
     const isExternalLink = Platform.OS === 'ios' ? event.navigationType === 'click' : true;
@@ -39,22 +48,34 @@ export default function HomeScreen() {
   return (
     <View style={{ flex: 1, backgroundColor: theme.color.background }}>
       <YgtStatusBar />
-      <WebView
-        ref={ref => {
-          if (!ref) return;
-          webViewRef.current = ref;
+      <Animated.View
+        style={{
+          width: '100%',
+          height: '100%',
+          opacity: fadeAnimationRef.current,
+          backgroundColor: theme.color.background,
         }}
-        source={{ uri }}
-        bounces={false}
-        applicationNameForUserAgent={'YgtangApp/1.0'}
-        allowsBackForwardNavigationGestures
-        domStorageEnabled
-        onError={() => {
-          setIsError(true);
-        }}
-        onNavigationStateChange={handleExternalLinks}
-        onShouldStartLoadWithRequest={handleExternalLinks}
-      />
+      >
+        <WebView
+          ref={ref => {
+            if (!ref) return;
+            webViewRef.current = ref;
+          }}
+          source={{ uri }}
+          bounces={false}
+          applicationNameForUserAgent={'YgtangApp/1.0'}
+          allowsBackForwardNavigationGestures
+          domStorageEnabled
+          onError={() => {
+            setIsError(true);
+          }}
+          onNavigationStateChange={handleExternalLinks}
+          onShouldStartLoadWithRequest={handleExternalLinks}
+          style={{
+            backgroundColor: theme.color.background,
+          }}
+        />
+      </Animated.View>
     </View>
   );
 }

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { StackNavigationProp } from '@react-navigation/stack';
 import LottieView from 'lottie-react-native';
 import { StyleSheet, View } from 'react-native';
 
@@ -7,7 +7,7 @@ import { MainNavigatorParamsType } from '~/navigation/MainNavigator';
 import theme from '~/styles/theme';
 
 interface SplashScreenProp {
-  navigation: NativeStackNavigationProp<MainNavigatorParamsType>;
+  navigation: StackNavigationProp<MainNavigatorParamsType>;
 }
 
 export default function SplashScreen({ navigation: { replace } }: SplashScreenProp) {
@@ -22,7 +22,7 @@ export default function SplashScreen({ navigation: { replace } }: SplashScreenPr
         autoPlay
         loop={false}
         duration={2000}
-        style={{ height: 374 }}
+        style={{ height: 374, backgroundColor: theme.color.gray02 }}
         onAnimationFinish={onSplashFinish}
       />
     </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,6 +1353,15 @@
   dependencies:
     nanoid "^3.1.23"
 
+"@react-navigation/stack@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.2.1.tgz#2b14473579eced6def5cca06860044d60e59d06e"
+  integrity sha512-JI7boxtPAMCBXi4VJHVEq61jLVHFW5f3npvbndS+XfOsv7Gf0f91HOVJ28DS5c2Fn4+CO4AByjUozzlN296X+A==
+  dependencies:
+    "@react-navigation/elements" "^1.3.3"
+    color "^3.1.3"
+    warn-once "^0.1.0"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -2431,7 +2440,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -2450,10 +2459,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@^1.0.7:
   version "1.4.0"
@@ -3860,6 +3885,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -6617,6 +6647,13 @@ simple-plist@^1.1.0:
     bplist-creator "0.1.0"
     bplist-parser "0.3.1"
     plist "^3.0.5"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
- 스플래시에서 홈으로 이동할 때 생기는 하얀색 깜빡임을 제거했어요.
- native로 별짓을 다해봤으나 해결 방법을 못찾다가 원인은 native에 있는 것이 아니고 webview에 있다는 걸 발견했는데요, webview 자체에 빨간색 배경화면을 넣었을 때 사진을 보면 알 수 있어요. 빨간색 배경화면 이전에는.. 흰색 깜빡임이 없죠?
![Simulator Screen Recording - iPhone 13 - 2022-06-13 at 23 16 46](https://user-images.githubusercontent.com/69200669/173381292-84d45717-1bdf-4d68-9281-62834d4ec91c.gif)
결국은.. 웹뷰 단에서 웹페이지를 로드할 때 생기는 시간 동안 흰 화면을 띄워버리는 것..
아래처럼요!
![Simulator Screen Recording - iPhone 13 - 2022-06-13 at 23 17 08](https://user-images.githubusercontent.com/69200669/173381305-26242ba3-3aa5-40a3-a529-50afebcfab7d.gif)

따라서 웹뷰 자체에 opacity animation을 줘서 fade in 되도록 했어요. 이게 확인해보니까 1700ms 정도 잡아야 흰색 깜빡임이 안보이더라구요.
![Simulator Screen Recording - iPhone 13 - 2022-06-13 at 23 47 45](https://user-images.githubusercontent.com/69200669/173381246-40735ca1-4d99-47e5-b865-da9876607160.gif)

최종적으로 스플래시 스크린 duration을 줄이기 위해선 splash에서 home으로 screen 이동시키는 것이 아니라 웹뷰가 띄워진  HomeScreen 위에 splash 모달 형식으로 띄우는 방식으로 해결 봐야할 것 같고요. 요거는 다른 이슈로 분리해서 진행할게요!

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
- https://reactnavigation.org/docs/stack-navigator#animations
- https://github.com/react-navigation/stack/blob/master/example/src/ModalStack.tsx