### PR TITLE
공유 커스텀 뷰 - 공유 데이터 contentType 전달

### DIFF
--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -8,7 +8,7 @@ import { Error } from '~/components/Error';
 import { YgtStatusBar } from '~/components/YgtStatusBar';
 import theme from '~/styles/theme';
 
-const BASE_URI = 'http://localhost:3000/';
+const BASE_URI = 'https://app.ygtang.kr/';
 
 const CONTENT_TYPE = {
   IMAGE: 'IMAGE',

--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -8,7 +8,7 @@ import { Error } from '~/components/Error';
 import { YgtStatusBar } from '~/components/YgtStatusBar';
 import theme from '~/styles/theme';
 
-const BASE_URI = 'https://app.ygtang.kr/';
+const BASE_URI = 'http://localhost:3000/';
 
 const CONTENT_TYPE = {
   IMAGE: 'IMAGE',
@@ -39,10 +39,12 @@ function isURL(url: string): boolean {
 const Share = () => {
   const [isError, setIsError] = useState(false);
   const [sharedData, setSharedData] = useState<string | ArrayBuffer>();
+  const [sharedMimeType, setSharedMimeType] = useState<string | ArrayBuffer>();
   const [contentType, setContentType] = useState<string>('');
   const webViewRef = useRef<WebView>();
 
   const setContentHandler = async ({ data, mimeType }: { data: string; mimeType: string }) => {
+    setSharedMimeType(mimeType);
     if (mimeType.startsWith('image/')) {
       setContentType(CONTENT_TYPE.IMAGE);
       const imageData = await urlTo64File(data);
@@ -77,6 +79,7 @@ const Share = () => {
       JSON.stringify({
         type: SHARE_EXTENTION_MESSAGE_TYPE,
         data: sharedData,
+        mimeType: sharedMimeType,
       })
     );
   };


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->
- contentType를 기본적으로 포함하는 것이 추후에도 좋다고 생각하였습니다.
- base64 -> blob으로 만들때 mimeType을 사용하기에 해당 코드가 추가되었습니다.

### 아래는 웹뷰에 추가될 코드입니다.
```ts
function base64ToBlob(base64: string, contentType = 'image/png', chunkLength = 512) {
  const byteCharsArray = Array.from(atob(base64.substr(base64.indexOf(',') + 1)));
  const chunksIterator = new Array(Math.ceil(byteCharsArray.length / chunkLength));
  const bytesArrays = [];

  for (let c = 0; c < chunksIterator.length; c++) {
    bytesArrays.push(
      new Uint8Array(
        byteCharsArray.slice(c * chunkLength, chunkLength * (c + 1)).map(s => s.charCodeAt(0))
      )
    );
  }

  const blob = new Blob(bytesArrays, { type: contentType });

  return blob;
}


setStateHandler({ blob: await base64ToBlob(data.data, data.mimeType), base64: data.data });
```

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->
