### PR TITLE
IOS - Refresh 토큰 ShareExtension과 공유하기

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,14 +22,16 @@ module.exports = {
       },
       extends: [
         'eslint:recommended',
+        'prettier',
         'plugin:@typescript-eslint/recommended',
         'plugin:react/recommended',
         'plugin:react-hooks/recommended',
         'plugin:import/typescript',
         'plugin:import/recommended',
       ],
-      plugins: ['react', 'react-native', 'import', 'simple-import-sort'],
+      plugins: ['prettier','react', 'react-native', 'import', 'simple-import-sort'],
       rules: {
+        'prettier/prettier': 'error',
         '@typescript-eslint/naming-convention': [
           'error',
           {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,5 +41,6 @@ target 'ShareExtention' do
 
   pod 'RNShareMenu', :path => '../node_modules/react-native-share-menu'
   pod 'react-native-webview', :path => '../node_modules/react-native-webview'
+  pod 'RNReactNativeSharedGroupPreferences', :path => '../node_modules/react-native-shared-group-preferences'
   # Manually link packages here to keep your extension bundle size minimal
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -299,6 +299,8 @@ PODS:
     - React
   - RNGestureHandler (2.4.2):
     - React-Core
+  - RNReactNativeSharedGroupPreferences (1.1.23):
+    - React
   - RNReanimated (2.8.0):
     - DoubleConversion
     - FBLazyVector
@@ -372,6 +374,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNReactNativeSharedGroupPreferences (from `../node_modules/react-native-shared-group-preferences`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNShareMenu (from `../node_modules/react-native-share-menu`)
@@ -454,6 +457,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNReactNativeSharedGroupPreferences:
+    :path: "../node_modules/react-native-shared-group-preferences"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -501,11 +506,12 @@ SPEC CHECKSUMS:
   ReactCommon: fab89a13b52f1ac42b59a0e4b4f76f21aea9eebe
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: 61628a2c859172551aa2100d3e73d1e57878392f
+  RNReactNativeSharedGroupPreferences: de0121a4224c267bc7e9fb16c398f3f087c8da81
   RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNShareMenu: c69282e50ac439737a86949a55c7b023b90027c8
   Yoga: 6671cf077f614314c22fd09ddf87d7abeee64e96
 
-PODFILE CHECKSUM: af986c7001c2a304b0fa5cac5dbf8c81e43ab1f3
+PODFILE CHECKSUM: 5b32dd8b30269b4e6c81febaa2f06b2a0f3fe1e0
 
 COCOAPODS: 1.11.3

--- a/ios/ShareExtention/ShareExtention.entitlements
+++ b/ios/ShareExtention/ShareExtention.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.reactjs.native.example.ygt-container</string>
+		<string>group.org.reactjs.native.example.ygt-share</string>
 	</array>
 </dict>
 </plist>

--- a/ios/ygt/Info.plist
+++ b/ios/ygt/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/ygt/Info.plist
+++ b/ios/ygt/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/ygt/ygt.entitlements
+++ b/ios/ygt/ygt.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.reactjs.native.example.ygt-container</string>
+		<string>group.org.reactjs.native.example.ygt-share</string>
 	</array>
 </dict>
 </plist>

--- a/ios/ygt/ygtRelease.entitlements
+++ b/ios/ygt/ygtRelease.entitlements
@@ -9,7 +9,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.reactjs.native.example.ygt-container</string>
+		<string>group.org.reactjs.native.example.ygt-share</string>
 	</array>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-native-safe-area-context": "^4.2.5",
     "react-native-screens": "^3.13.1",
     "react-native-share-menu": "^5.0.2",
+    "react-native-shared-group-preferences": "^1.1.23",
     "react-native-webview": "^11.18.2",
     "url-parse": "^1.5.10"
   },
@@ -34,6 +35,7 @@
     "@types/react-native": "^0.67.3",
     "@types/react-native-dotenv": "^0.2.0",
     "@types/react-native-share-menu": "^5.0.2",
+    "@types/react-native-shared-group-preferences": "^1.1.1",
     "@types/react-test-renderer": "^17.0.1",
     "@types/url-parse": "^1.4.8",
     "@typescript-eslint/eslint-plugin": "^5.18.0",

--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -6,20 +6,20 @@ import URL from 'url-parse';
 
 import { Error } from '~/components/Error';
 import { YgtStatusBar } from '~/components/YgtStatusBar';
+import {
+  BASE_URI,
+  SHARE_EXTENTION_MESSAGE_TYPE,
+  SHARE_WEB_MESSAGE_STATE,
+  SYNC_YGT_RT,
+} from '~/constants/common';
 import { useShareWebToken } from '~/hooks/useShareWebToken';
 import theme from '~/styles/theme';
-
-const BASE_URI = 'http://localhost:3000/';
 
 const CONTENT_TYPE = {
   IMAGE: 'IMAGE',
   TEXT: 'TEXT',
   LINK: 'LINK',
 } as const;
-
-const SHARE_EXTENTION_MESSAGE_TYPE = 'YgtangAppShareData';
-const SHARE_WEB_MESSAGE_STATE = 'YgtangWebShareState';
-const SYNC_YGT_RT = 'SYNC_YGT_RT';
 
 async function urlTo64File(url: string): Promise<string | ArrayBuffer> {
   const data = await fetch(url);

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,0 +1,5 @@
+export const SYNC_YGT_RT = 'SYNC_YGT_RT';
+export const BASE_URI = 'https://app.ygtang.kr/';
+export const SHARE_EXTENTION_MESSAGE_TYPE = 'YgtangAppShareData';
+export const SHARE_WEB_MESSAGE_STATE = 'YgtangWebShareState';
+export const APP_GROUP_KEY = 'group.org.reactjs.native.example.ygt-share';

--- a/src/hooks/useShareWebToken.ts
+++ b/src/hooks/useShareWebToken.ts
@@ -7,22 +7,17 @@ const localStorageUserTokenKeys = {
   refreshToken: 'ygtrfhtk',
 } as const;
 
+const APP_GROUP_KEY = 'group.org.reactjs.native.example.ygt-share';
+
 export function useShareWebToken() {
   const setRefreshToken = async (value: string) => {
-    await SharedGroupPreferences.setItem(
-      SYNC_YGT_RT,
-      value,
-      'group.org.reactjs.native.example.ygt-share'
-    );
+    await SharedGroupPreferences.setItem(SYNC_YGT_RT, value, APP_GROUP_KEY);
   };
 
   const makeInjectedJavaScript = async () => {
     if (Platform.OS !== 'ios') return `(function() {})();`;
     try {
-      const refreshToken = await SharedGroupPreferences.getItem(
-        SYNC_YGT_RT,
-        'group.org.reactjs.native.example.ygt-share'
-      );
+      const refreshToken = await SharedGroupPreferences.getItem(SYNC_YGT_RT, APP_GROUP_KEY);
       return `(function() {window.localStorage.setItem('${localStorageUserTokenKeys.refreshToken}','${refreshToken}');})();`;
     } catch (error) {
       if (error === 0) console.error('App Group이 없습니다.');

--- a/src/hooks/useShareWebToken.ts
+++ b/src/hooks/useShareWebToken.ts
@@ -1,13 +1,12 @@
 import { Platform } from 'react-native';
 import SharedGroupPreferences from 'react-native-shared-group-preferences';
 
-const SYNC_YGT_RT = 'SYNC_YGT_RT';
+import { APP_GROUP_KEY, SYNC_YGT_RT } from '~/constants/common';
+
 const localStorageUserTokenKeys = {
   accessToken: 'ygtlsat',
   refreshToken: 'ygtrfhtk',
 } as const;
-
-const APP_GROUP_KEY = 'group.org.reactjs.native.example.ygt-share';
 
 export function useShareWebToken() {
   const setRefreshToken = async (value: string) => {

--- a/src/hooks/useShareWebToken.ts
+++ b/src/hooks/useShareWebToken.ts
@@ -18,7 +18,16 @@ export function useShareWebToken() {
     if (Platform.OS !== 'ios') return `(function() {})();`;
     try {
       const refreshToken = await SharedGroupPreferences.getItem(SYNC_YGT_RT, APP_GROUP_KEY);
-      return `(function() {window.localStorage.setItem('${localStorageUserTokenKeys.refreshToken}','${refreshToken}');})();`;
+      return `(function() {
+          window.localStorage.setItem('${
+            localStorageUserTokenKeys.refreshToken
+          }','${refreshToken}');
+          if(${!refreshToken}) {
+            window.localStorage.setItem('${
+              localStorageUserTokenKeys.accessToken
+            }','${refreshToken}');
+          }
+        })();`;
     } catch (error) {
       if (error === 0) console.error('App Group이 없습니다.');
       return `(function() {})();`;

--- a/src/hooks/useShareWebToken.ts
+++ b/src/hooks/useShareWebToken.ts
@@ -1,0 +1,34 @@
+import { Platform } from 'react-native';
+import SharedGroupPreferences from 'react-native-shared-group-preferences';
+
+const SYNC_YGT_RT = 'SYNC_YGT_RT';
+const localStorageUserTokenKeys = {
+  accessToken: 'ygtlsat',
+  refreshToken: 'ygtrfhtk',
+} as const;
+
+export function useShareWebToken() {
+  const setRefreshToken = async (value: string) => {
+    await SharedGroupPreferences.setItem(
+      SYNC_YGT_RT,
+      value,
+      'group.org.reactjs.native.example.ygt-share'
+    );
+  };
+
+  const makeInjectedJavaScript = async () => {
+    if (Platform.OS !== 'ios') return `(function() {})();`;
+    try {
+      const refreshToken = await SharedGroupPreferences.getItem(
+        SYNC_YGT_RT,
+        'group.org.reactjs.native.example.ygt-share'
+      );
+      return `(function() {window.localStorage.setItem('${localStorageUserTokenKeys.refreshToken}','${refreshToken}');})();`;
+    } catch (error) {
+      if (error === 0) console.error('App Group이 없습니다.');
+      return `(function() {})();`;
+    }
+  };
+
+  return { makeInjectedJavaScript, setRefreshToken };
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -4,13 +4,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 
 import { Error } from '~/components/Error';
+import { BASE_URI, SYNC_YGT_RT } from '~/constants/common';
 import { useShareWebToken } from '~/hooks/useShareWebToken';
 import theme from '~/styles/theme';
-
-const SYNC_YGT_RT = 'SYNC_YGT_RT';
-
-// const uri = 'https://app.ygtang.kr/';
-const uri = 'http://localhost:3000/';
 
 export default function HomeScreen() {
   const [isError, setIsError] = useState(false);
@@ -85,7 +81,7 @@ export default function HomeScreen() {
             if (!ref) return;
             webViewRef.current = ref;
           }}
-          source={{ uri }}
+          source={{ uri: BASE_URI }}
           bounces={false}
           applicationNameForUserAgent={'YgtangApp/1.0'}
           allowsBackForwardNavigationGestures

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -105,5 +105,3 @@ export default function HomeScreen() {
     </SafeAreaView>
   );
 }
-
-//https://github.com/react-native-webview/react-native-webview/issues/1291

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,7 +1355,7 @@
 
 "@react-navigation/stack@^6.2.1":
   version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.2.1.tgz#2b14473579eced6def5cca06860044d60e59d06e"
+  resolved "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.2.1.tgz"
   integrity sha512-JI7boxtPAMCBXi4VJHVEq61jLVHFW5f3npvbndS+XfOsv7Gf0f91HOVJ28DS5c2Fn4+CO4AByjUozzlN296X+A==
   dependencies:
     "@react-navigation/elements" "^1.3.3"
@@ -1520,6 +1520,11 @@
   resolved "https://registry.npmjs.org/@types/react-native-share-menu/-/react-native-share-menu-5.0.2.tgz"
   integrity sha512-Qa9DGfL6Bvng2DXgCK0fFzdi9SJMGfs06MLSkCfSXBCGKlFLzSHCsXztvXlCCChn3dQArFHyz/uRUN3Sbt6LtQ==
 
+"@types/react-native-shared-group-preferences@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@types/react-native-shared-group-preferences/-/react-native-shared-group-preferences-1.1.1.tgz"
+  integrity sha512-EHkkOzcnZSxUbI79jnIdJZmXLw7qYFdrZ1C0ORYSkRU3tKYk1RCgZhfNI87yjCZpACpBcTiHQP5L/+uED/6mnA==
+
 "@types/react-native@^0.67.3":
   version "0.67.3"
   resolved "https://registry.npmjs.org/@types/react-native/-/react-native-0.67.3.tgz"
@@ -1535,9 +1540,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
-  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
+  version "17.0.47"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
+  integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2476,7 +2481,7 @@ color-name@^1.0.0, color-name@~1.1.4:
 
 color-string@^1.6.0:
   version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  resolved "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
     color-name "^1.0.0"
@@ -2484,7 +2489,7 @@ color-string@^1.6.0:
 
 color@^3.1.3:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  resolved "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
   dependencies:
     color-convert "^1.9.3"
@@ -3898,7 +3903,7 @@ is-arrayish@^0.2.1:
 
 is-arrayish@^0.3.1:
   version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
@@ -6103,6 +6108,11 @@ react-native-share-menu@^5.0.2:
   resolved "https://registry.npmjs.org/react-native-share-menu/-/react-native-share-menu-5.0.5.tgz"
   integrity sha512-AUetD75x2PKM1sgLqcEBeeI1LHVM4WgiY+SHTGbbSbrnPzjt9oadt8ZNw/ICNYM91toW4WQu+WktuXEIIarBQg==
 
+react-native-shared-group-preferences@^1.1.23:
+  version "1.1.23"
+  resolved "https://registry.npmjs.org/react-native-shared-group-preferences/-/react-native-shared-group-preferences-1.1.23.tgz"
+  integrity sha512-ZZyLNksXtuQU2AIe0RDNvjYewy2c8EVDNuA7DE141/43CaWjHScIqyQ+vOhQDVscAq/9XpfYWHQmeu2uteRqCg==
+
 react-native-webview@^11.18.2:
   version "11.18.2"
   resolved "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.18.2.tgz"
@@ -6675,7 +6685,7 @@ simple-plist@^1.1.0:
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz"
   integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
   dependencies:
     is-arrayish "^0.3.1"


### PR DESCRIPTION
# ⛳️작업 내용
- IOS일 경우, 번들 ID가 달라 webView가 localstoage를 공유하지 못했습니다.
  - 따라서 react-native-shared-group-preferences 패키지를 통해서 그룹간의 native stoage를 공유해서 사용하도록 구현했습니다.
- onMessage에 `refreshToken`을 저장할 수 있도록 구현했습니다.
- 로그아웃할 경우, accessToken 빈 string 처리해서 공유하기를 열더라도 온보딩으로 보내기처리했습니다.

- `injectJavaScript`가 생각과 달리 webview가 load되고 실행될 줄 알았으나 그렇지 않았습니다. 
  - 따라서 [이슈](https://github.com/react-native-webview/react-native-webview/issues/1291)에 언급된 대로 `onLoadEnd` 시점에 `injectJavaScript`를 실행하도록 구현했습니다.
  
ex)
```ts
const handleLoadEnd = async () => {
  const injectedRefreshJavaScript = await makeInjectedJavaScript();
  webViewRef?.current?.injectJavaScript(injectedRefreshJavaScript || '');
};
```
<!-- 작업한 사항을 간략하게 적어주세요 -->

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
https://user-images.githubusercontent.com/59507527/174853339-5b247494-ec3a-44e5-81e6-7d9923c4a7c8.mov



# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->
### `useShareWebToken` refreshtoken 공유 hooks
```ts
import { useShareWebToken } from '~/hooks/useShareWebToken';
const { makeInjectedJavaScript, setRefreshToken } = useShareWebToken();

// 메시지 받는 부분에서 web으로 부터 전달 받은 토큰저장합니다.
const onReciveMessage = async (event: WebViewMessageEvent) => {
  const data = JSON.parse(event.nativeEvent.data);
  if (data.type === SYNC_YGT_RT) {
    await setRefreshToken(data.data);
  }
};

// makeInjectedJavaScript를 통해 web에 토큰을 넣는 코드를 만듭니다.
const handleLoadEnd = async () => {
  const injectedRefreshJavaScript = await makeInjectedJavaScript();
  webViewRef?.current?.injectJavaScript(injectedRefreshJavaScript || '');
};
```
# 📎레퍼런스
https://github.com/react-native-webview/react-native-webview/issues/1291
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

close #89 
