### PR TITLE
안드로이드 백 버튼 false 이벤트 핸들링

### DIFF
--- a/src/hooks/useWebViewNavigateWrapping.ts
+++ b/src/hooks/useWebViewNavigateWrapping.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { WebViewMessageEvent } from 'react-native-webview';
+
+export function useWebViewNavigateWrapping() {
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  const handleMessage = ({ nativeEvent }: WebViewMessageEvent) => {
+    if (nativeEvent.data === 'navigationStateChange') {
+      setCanGoBack(nativeEvent.canGoBack);
+    }
+  };
+
+  return {
+    canGoBack,
+    setCanGoBack,
+    injectCode: WebViewInjectCode,
+    handleMessage,
+  };
+}
+
+// ref: https://github.com/react-native-webview/react-native-webview/issues/24#issuecomment-483956651
+const WebViewInjectCode = `
+    (function() {
+      function wrap(fn) {
+        return function wrapper() {
+          var res = fn.apply(this, arguments);
+          window.ReactNativeWebView.postMessage('navigationStateChange');
+          return res;
+        }
+      }
+
+      history.pushState = wrap(history.pushState);
+      history.replaceState = wrap(history.replaceState);
+      window.addEventListener('popstate', function() {
+        window.ReactNativeWebView.postMessage('navigationStateChange');
+      });
+    })();
+    true;
+  `;


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->

- React Native에서 제공하는 백버튼 이벤트가 올바르게 사용되지 않았던 문제를 해결합니다.
- 웹뷰의 Navigate 이벤트의 경우 History API의 pushState를 올바르게 핸들링하지 못한다는 이슈가 있어, message를 이용해 랩핑하는 방식을 사용하였습니다.

안드로이드만 사용할까 싶었지만, 추후에 iOS에서도 분명히 사용하게 될 것 같아서 냅뒀습니다

# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

https://user-images.githubusercontent.com/6638675/176151710-d34724f4-101c-40cb-98e8-bb107c0e3fd5.mp4

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

https://github.com/react-native-webview/react-native-webview/issues/24#issuecomment-483956651
https://github.com/react-native-webview/react-native-webview