### PR TITLE
안드로이드 이미지 저장 토스트 메세지 오류 해결

### DIFF
--- a/src/utils/imageDownload/imageDownload.ts
+++ b/src/utils/imageDownload/imageDownload.ts
@@ -50,9 +50,13 @@ export async function imageDownload(
   }
 
   if (Platform.OS === 'android') {
+    const { dirs } = RNFetchBlob.fs;
+    const downloadPath = dirs.DownloadDir + '/ygtang' + event.url;
+
     RNFetchBlob.config({
       fileCache: true,
-      addAndroidDownloads: { useDownloadManager: true, notification: true },
+      path: downloadPath,
+      addAndroidDownloads: { useDownloadManager: true, notification: true, path: downloadPath },
     })
       .fetch('GET', event.url)
       .then(() => {
@@ -62,7 +66,8 @@ export async function imageDownload(
         });
         webViewRef.current?.postMessage(stringMessageObject);
       })
-      .catch(() => {
+      .catch((e: any) => {
+        console.log(e);
         const stringMessageObject = getStringPostMessageObject({
           type: WEBVIEW_MESSAGE_TYPE.SEND_TOAST_MESSAGE,
           data: FAILED_IMAGE_DOWNLOAD_MESSAGE,

--- a/src/utils/imageDownload/imageDownload.ts
+++ b/src/utils/imageDownload/imageDownload.ts
@@ -66,8 +66,7 @@ export async function imageDownload(
         });
         webViewRef.current?.postMessage(stringMessageObject);
       })
-      .catch((e: any) => {
-        console.log(e);
+      .catch(() => {
         const stringMessageObject = getStringPostMessageObject({
           type: WEBVIEW_MESSAGE_TYPE.SEND_TOAST_MESSAGE,
           data: FAILED_IMAGE_DOWNLOAD_MESSAGE,


### PR DESCRIPTION
# ⛳️작업 내용
<!-- 작업한 사항을 간략하게 적어주세요 -->

안드로이드 환경에서 이미지 다운로드 시, 다운로드는 정상적으로 되나 토스트 메세지로 실패했다는 노티가 나오는 버그를 해결 했어요

https://github.com/joltup/rn-fetch-blob/issues/214 

안드로이드 환경에서 이미지 저장시에 사용 중이던 `rn-fetch-blob`의 이슈를 확인해 해결 했어요

> 이미지 다운로드 path를 설정하지 않아서 발생했던 이슈였습니다.



# 📸스크린샷
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

# ⚡️사용 방법
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

# 📎레퍼런스
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

closes #126
