### PR TITLE
모바일 공유하기 이후, 자동 닫히기

### DIFF
--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -89,14 +89,26 @@ const Share = () => {
     );
   };
 
-  const onReciveMessage = async (event: WebViewMessageEvent) => {
+  const handleShareWebMessage = (data: { type: string; data: string }) => {
+    if (data.type !== SHARE_WEB_MESSAGE_STATE) return;
+    switch (data.data) {
+      case 'READY':
+        sendDataToWebView();
+        break;
+      case 'SHARE_COMPLETE':
+        ShareMenuReactView.dismissExtension();
+        break;
+      default:
+        return;
+    }
+  };
+
+  const onReceiveMessage = async (event: WebViewMessageEvent) => {
     const data = JSON.parse(event.nativeEvent.data);
     if (data.type === SYNC_YGT_RT) {
       await setRefreshToken(data.data);
     }
-    if (data.type === SHARE_WEB_MESSAGE_STATE && data.data === 'READY') {
-      sendDataToWebView();
-    }
+    handleShareWebMessage(data);
   };
 
   const getAddContentURI = () => {
@@ -156,7 +168,7 @@ const Share = () => {
           }}
           onNavigationStateChange={handleExternalLinks}
           onShouldStartLoadWithRequest={handleExternalLinks}
-          onMessage={onReciveMessage}
+          onMessage={onReceiveMessage}
         />
       )}
     </View>


### PR DESCRIPTION
# ⛳️작업 내용
- ios share extension들은 공유 이후, 자동으로 닫히는 플로우가 정상적이며 요구사항입니다.
- 이를 위해서 `SHARE_COMPLETE`를 WEB으로 붙어받아 종료하는 플로우를 구현했습니다.

연관작업 : https://github.com/depromeet/ygtang-client/pull/517
<!-- 작업한 사항을 간략하게 적어주세요 -->

# 📸스크린샷
https://user-images.githubusercontent.com/59507527/212137004-6fc931f7-4b77-4495-b7af-1687da3060df.mov

